### PR TITLE
Feature/badge point

### DIFF
--- a/src/main/java/com/devee/devhive/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/devee/devhive/domain/admin/controller/AdminController.java
@@ -3,9 +3,11 @@ package com.devee.devhive.domain.admin.controller;
 import static com.devee.devhive.domain.user.type.Role.ADMIN;
 import static com.devee.devhive.global.exception.ErrorCode.UNAUTHORIZED;
 
+import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
 import com.devee.devhive.domain.badge.entity.dto.CreateBadgeDto;
 import com.devee.devhive.domain.badge.service.BadgeService;
 import com.devee.devhive.domain.techstack.entity.dto.CreateTechStackDto;
+import com.devee.devhive.domain.techstack.entity.dto.TechStackDto;
 import com.devee.devhive.domain.techstack.service.TechStackService;
 import com.devee.devhive.domain.user.entity.User;
 import com.devee.devhive.domain.user.service.UserService;
@@ -14,9 +16,13 @@ import com.devee.devhive.global.exception.CustomException;
 import com.devee.devhive.global.s3.S3Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,7 +72,6 @@ public class AdminController {
 
   @DeleteMapping("/tech-stack/{techStackId}")
   @Operation(summary = "테크스택 삭제", description = "테크스택의 고유 ID로 테크스택 삭제")
-
   public void deleteTechStack(
       @AuthenticationPrincipal PrincipalDetails principal, @PathVariable Long techStackId
   ) {
@@ -76,6 +81,15 @@ public class AdminController {
     }
 
     techStackService.deleteTechStack(techStackId);
+  }
+
+  @GetMapping("/tech-stacks")
+  @Operation(summary = "테크스택 목록 조회", description = "서버에 등록된 모든 테크스택 목록 조회")
+  public ResponseEntity<List<TechStackDto>> getAllTechStacks() {
+    return ResponseEntity.ok(techStackService.getAllTechStacks().stream()
+        .map(TechStackDto::from)
+        .collect(Collectors.toList())
+    );
   }
 
   @PostMapping("/badge")
@@ -102,5 +116,14 @@ public class AdminController {
       throw new CustomException(UNAUTHORIZED);
     }
     badgeService.deleteBadge(badgeId);
+  }
+
+  @GetMapping("/badges")
+  @Operation(summary = "뱃지 목록 조회", description = "서버에 등록된 모든 뱃지 목록 조회")
+  public ResponseEntity<List<BadgeDto>> getAllBadges() {
+    return ResponseEntity.ok(badgeService.getAllBadges().stream()
+        .map(BadgeDto::from)
+        .collect(Collectors.toList())
+    );
   }
 }

--- a/src/main/java/com/devee/devhive/domain/badge/entity/Badge.java
+++ b/src/main/java/com/devee/devhive/domain/badge/entity/Badge.java
@@ -1,5 +1,6 @@
 package com.devee.devhive.domain.badge.entity;
 
+import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,4 +21,12 @@ public class Badge {
     private Long id;
     private String name;
     private String imageUrl;
+
+    public static Badge from(BadgeDto dto) {
+        return Badge.builder()
+            .id(dto.getId())
+            .name(dto.getName())
+            .imageUrl(dto.getImage())
+            .build();
+    }
 }

--- a/src/main/java/com/devee/devhive/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/devee/devhive/domain/badge/repository/BadgeRepository.java
@@ -1,10 +1,13 @@
 package com.devee.devhive.domain.badge.repository;
 
 import com.devee.devhive.domain.badge.entity.Badge;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
   boolean existsByName(String name);
+
+  List<Badge> findAllByOrderByNameAsc();
 }

--- a/src/main/java/com/devee/devhive/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/devee/devhive/domain/badge/service/BadgeService.java
@@ -4,15 +4,17 @@ import static com.devee.devhive.global.exception.ErrorCode.DUPLICATE_BADGE;
 import static com.devee.devhive.global.exception.ErrorCode.NOT_FOUND_BADGE;
 
 import com.devee.devhive.domain.badge.entity.Badge;
-import com.devee.devhive.domain.badge.repository.BadgeRepository;
+import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
 import com.devee.devhive.domain.badge.entity.dto.CreateBadgeDto;
+import com.devee.devhive.domain.badge.repository.BadgeRepository;
 import com.devee.devhive.global.exception.CustomException;
 import com.devee.devhive.global.s3.S3Service;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +22,12 @@ public class BadgeService {
 
   private final BadgeRepository badgeRepository;
   private final S3Service s3Service;
+
+  public List<BadgeDto> getAllBadges() {
+    return badgeRepository.findAll().stream()
+        .map(BadgeDto::from)
+        .collect(Collectors.toList());
+  }
 
   public void createBadge(CreateBadgeDto badgeDto) {
     if (badgeRepository.existsByName(badgeDto.getName())) {

--- a/src/main/java/com/devee/devhive/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/devee/devhive/domain/badge/service/BadgeService.java
@@ -4,7 +4,6 @@ import static com.devee.devhive.global.exception.ErrorCode.DUPLICATE_BADGE;
 import static com.devee.devhive.global.exception.ErrorCode.NOT_FOUND_BADGE;
 
 import com.devee.devhive.domain.badge.entity.Badge;
-import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
 import com.devee.devhive.domain.badge.entity.dto.CreateBadgeDto;
 import com.devee.devhive.domain.badge.repository.BadgeRepository;
 import com.devee.devhive.global.exception.CustomException;
@@ -12,7 +11,6 @@ import com.devee.devhive.global.s3.S3Service;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,10 +21,8 @@ public class BadgeService {
   private final BadgeRepository badgeRepository;
   private final S3Service s3Service;
 
-  public List<BadgeDto> getAllBadges() {
-    return badgeRepository.findAll().stream()
-        .map(BadgeDto::from)
-        .collect(Collectors.toList());
+  public List<Badge> getAllBadges() {
+    return badgeRepository.findAllByOrderByNameAsc();
   }
 
   public void createBadge(CreateBadgeDto badgeDto) {

--- a/src/main/java/com/devee/devhive/domain/project/review/dto/EvaluationForm.java
+++ b/src/main/java/com/devee/devhive/domain/project/review/dto/EvaluationForm.java
@@ -1,6 +1,6 @@
 package com.devee.devhive.domain.project.review.dto;
 
-import com.devee.devhive.domain.project.type.EvaluationItem;
+import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,23 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class EvaluationForm {
 
-  private int manner;
-  private int contribution;
-  private int communication;
-  private int schedule;
-  private int professionalism;
-
-  public int getTotalScore() {
-    return manner + contribution + communication + schedule + professionalism;
-  }
-
-  public int getValue(EvaluationItem item) {
-    return switch (item) {
-      case MANNER -> manner;
-      case CONTRIBUTION -> contribution;
-      case COMMUNICATION -> communication;
-      case SCHEDULE -> schedule;
-      case PROFESSIONALISM -> professionalism;
-    };
-  }
+  private BadgeDto badgeDto;
+  private int point;
 }

--- a/src/main/java/com/devee/devhive/domain/project/review/evaluation/entity/Evaluation.java
+++ b/src/main/java/com/devee/devhive/domain/project/review/evaluation/entity/Evaluation.java
@@ -1,10 +1,8 @@
 package com.devee.devhive.domain.project.review.evaluation.entity;
 
+import com.devee.devhive.domain.badge.entity.Badge;
 import com.devee.devhive.domain.project.review.entity.ProjectReview;
-import com.devee.devhive.domain.project.type.EvaluationItem;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,8 +28,9 @@ public class Evaluation {
     @JoinColumn(name = "project_review_id")
     private ProjectReview projectReview;
 
-    @Enumerated(EnumType.STRING)
-    private EvaluationItem evaluationItem;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id")
+    private Badge badge;
 
     private int point;
 }

--- a/src/main/java/com/devee/devhive/domain/project/review/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/devee/devhive/domain/project/review/evaluation/service/EvaluationService.java
@@ -1,13 +1,12 @@
 package com.devee.devhive.domain.project.review.evaluation.service;
 
+import com.devee.devhive.domain.badge.entity.Badge;
 import com.devee.devhive.domain.project.review.dto.EvaluationForm;
 import com.devee.devhive.domain.project.review.entity.ProjectReview;
 import com.devee.devhive.domain.project.review.evaluation.entity.Evaluation;
 import com.devee.devhive.domain.project.review.evaluation.repository.EvaluationRepository;
-import com.devee.devhive.domain.project.type.EvaluationItem;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,32 +16,14 @@ public class EvaluationService {
 
   private final EvaluationRepository evaluationRepository;
 
-  public List<Evaluation> saveAllEvaluations(ProjectReview review, EvaluationForm form) {
-    List<Evaluation> evaluationList = getEvaluationList(review, form);
+  public List<Evaluation> saveAllEvaluations(ProjectReview review, List<EvaluationForm> forms) {
+    List<Evaluation> evaluationList = forms.stream()
+        .map(evaluationForm -> Evaluation.builder()
+            .projectReview(review)
+            .badge(Badge.from(evaluationForm.getBadgeDto()))
+            .point(evaluationForm.getPoint())
+            .build()).collect(Collectors.toList());
+
     return evaluationRepository.saveAll(evaluationList);
-  }
-
-  public List<Evaluation> getEvaluationList(ProjectReview review, EvaluationForm form) {
-    return getAllEvaluations(review, form);
-  }
-
-  private List<Evaluation> getAllEvaluations(ProjectReview review, EvaluationForm form) {
-    return Stream.of(
-            EvaluationItem.MANNER,
-            EvaluationItem.CONTRIBUTION,
-            EvaluationItem.COMMUNICATION,
-            EvaluationItem.SCHEDULE,
-            EvaluationItem.PROFESSIONALISM
-        )
-        .map(item -> getEvaluation(review, item, form.getValue(item)))
-        .collect(Collectors.toList());
-  }
-
-  private Evaluation getEvaluation(ProjectReview review, EvaluationItem evaluationItem, int point) {
-    return Evaluation.builder()
-        .projectReview(review)
-        .evaluationItem(evaluationItem)
-        .point(point)
-        .build();
   }
 }

--- a/src/main/java/com/devee/devhive/domain/project/review/service/ProjectReviewService.java
+++ b/src/main/java/com/devee/devhive/domain/project/review/service/ProjectReviewService.java
@@ -10,6 +10,7 @@ import com.devee.devhive.domain.project.review.repository.ProjectReviewRepositor
 import com.devee.devhive.domain.project.type.ProjectStatus;
 import com.devee.devhive.domain.user.entity.User;
 import com.devee.devhive.global.exception.CustomException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,7 +32,7 @@ public class ProjectReviewService {
 
   // 정보를 바탕으로 리뷰 등록
   public ProjectReview submitReview(Long projectId, Long targetUserId, User user,
-      Project project, User targetUser, EvaluationForm form
+      Project project, User targetUser, List<EvaluationForm> forms
   ) {
     // 리뷰는 프로젝트가 완료된 상태에서만 작성 가능
     if (project.getStatus() != ProjectStatus.COMPLETE) {
@@ -41,13 +42,14 @@ public class ProjectReviewService {
     if (isReviewed(projectId, user.getId(), targetUserId)) {
       throw new CustomException(ALREADY_SUBMIT_TARGETUSER);
     }
+    // 총 합계
+    int totalScore = forms.stream().mapToInt(EvaluationForm::getPoint).sum();
 
-    return projectReviewRepository.saveAndFlush(
-        ProjectReview.builder()
+    return projectReviewRepository.save(ProjectReview.builder()
             .project(project)
             .reviewerUser(user)
             .targetUser(targetUser)
-            .totalScore(form.getTotalScore())
+            .totalScore(totalScore)
             .build());
   }
 

--- a/src/main/java/com/devee/devhive/domain/project/type/EvaluationItem.java
+++ b/src/main/java/com/devee/devhive/domain/project/type/EvaluationItem.java
@@ -1,9 +1,0 @@
-package com.devee.devhive.domain.project.type;
-
-public enum EvaluationItem {
-    MANNER,           // 매너지수
-    CONTRIBUTION,     // 기여도
-    COMMUNICATION,    // 소통
-    SCHEDULE,         // 일정준수
-    PROFESSIONALISM   // 전문성
-}

--- a/src/main/java/com/devee/devhive/domain/techstack/repository/TechStackRepository.java
+++ b/src/main/java/com/devee/devhive/domain/techstack/repository/TechStackRepository.java
@@ -1,6 +1,7 @@
 package com.devee.devhive.domain.techstack.repository;
 
 import com.devee.devhive.domain.techstack.entity.TechStack;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface TechStackRepository extends JpaRepository<TechStack, Long> {
   TechStack findByName(String techStackName);
 
   boolean existsByName(String name);
+
+  List<TechStack> findAllByOrderByNameAsc();
 }

--- a/src/main/java/com/devee/devhive/domain/techstack/service/TechStackService.java
+++ b/src/main/java/com/devee/devhive/domain/techstack/service/TechStackService.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +47,9 @@ public class TechStackService {
     s3Service.delete(filename);
 
     techStackRepository.delete(techStack);
+  }
+
+  public List<TechStack> getAllTechStacks() {
+    return techStackRepository.findAllByOrderByNameAsc();
   }
 }

--- a/src/main/java/com/devee/devhive/domain/user/badge/entity/UserBadge.java
+++ b/src/main/java/com/devee/devhive/domain/user/badge/entity/UserBadge.java
@@ -14,8 +14,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -32,4 +34,6 @@ public class UserBadge extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "badge_id")
     private Badge badge;
+
+    private int totalScore;
 }

--- a/src/main/java/com/devee/devhive/domain/user/badge/service/UserBadgeService.java
+++ b/src/main/java/com/devee/devhive/domain/user/badge/service/UserBadgeService.java
@@ -1,7 +1,6 @@
 package com.devee.devhive.domain.user.badge.service;
 
 import com.devee.devhive.domain.badge.entity.Badge;
-import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
 import com.devee.devhive.domain.badge.service.BadgeService;
 import com.devee.devhive.domain.project.review.evaluation.entity.Evaluation;
 import com.devee.devhive.domain.user.badge.entity.UserBadge;
@@ -25,13 +24,13 @@ public class UserBadgeService {
     }
 
     public List<UserBadge> create(User user) {
-        List<BadgeDto> badgeDtoList = badgeService.getAllBadges();
+        List<Badge> badges = badgeService.getAllBadges();
 
-        List<UserBadge> userBadges = badgeDtoList.stream()
-            .map(badgeDto -> UserBadge.builder()
+        List<UserBadge> userBadges = badges.stream()
+            .map(badge -> UserBadge.builder()
             .user(user)
             .totalScore(0)
-            .badge(Badge.from(badgeDto))
+            .badge(badge)
             .build()).toList();
 
         return userBadgeRepository.saveAll(userBadges);

--- a/src/main/java/com/devee/devhive/domain/user/badge/service/UserBadgeService.java
+++ b/src/main/java/com/devee/devhive/domain/user/badge/service/UserBadgeService.java
@@ -1,8 +1,15 @@
 package com.devee.devhive.domain.user.badge.service;
 
+import com.devee.devhive.domain.badge.entity.Badge;
+import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
+import com.devee.devhive.domain.badge.service.BadgeService;
+import com.devee.devhive.domain.project.review.evaluation.entity.Evaluation;
 import com.devee.devhive.domain.user.badge.entity.UserBadge;
+import com.devee.devhive.domain.user.entity.User;
 import com.devee.devhive.domain.user.repository.UserBadgeRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +18,46 @@ import org.springframework.stereotype.Service;
 public class UserBadgeService {
 
     private final UserBadgeRepository userBadgeRepository;
+    private final BadgeService badgeService;
 
     public List<UserBadge> getUserBadges(Long userId) {
         return userBadgeRepository.findAllByUserId(userId);
+    }
+
+    public List<UserBadge> create(User user) {
+        List<BadgeDto> badgeDtoList = badgeService.getAllBadges();
+
+        List<UserBadge> userBadges = badgeDtoList.stream()
+            .map(badgeDto -> UserBadge.builder()
+            .user(user)
+            .totalScore(0)
+            .badge(Badge.from(badgeDto))
+            .build()).toList();
+
+        return userBadgeRepository.saveAll(userBadges);
+    }
+
+    public void updatePoint(User user, List<Evaluation> evaluationList) {
+        List<UserBadge> userBadges = getUserBadges(user.getId());
+        // 유저의 첫 리뷰인 경우 유저뱃지 생성
+        if (userBadges.isEmpty()) {
+            userBadges = create(user);
+        }
+
+        // 맵 <평가 항목(뱃지아이디), 점수>
+        Map<Long, Integer> badgePointsMap = evaluationList.stream()
+            .collect(Collectors.toMap(
+                evaluation -> evaluation.getBadge().getId(), Evaluation::getPoint
+            ));
+        // 유저 뱃지 점수 업데이트
+        userBadges.forEach(userBadge -> {
+            Long badgeId = userBadge.getBadge().getId();
+            badgePointsMap.computeIfPresent(badgeId, (key, value) -> {
+                userBadge.setTotalScore(userBadge.getTotalScore() + value);
+                return userBadge.getTotalScore();
+            });
+        });
+
+        userBadgeRepository.saveAll(userBadges);
     }
 }

--- a/src/main/java/com/devee/devhive/global/config/SecurityConfig.java
+++ b/src/main/java/com/devee/devhive/global/config/SecurityConfig.java
@@ -97,7 +97,9 @@ public class SecurityConfig {
                 "/api/users/{userId}/careers",
                 "/api/projects/{projectId}/vote",
                 "api/comments/projects/{projectId}",
-                "/login/"
+                "/login/",
+                "/api/admin/tech-stacks",
+                "/api/admin/badges"
             ).permitAll()
 
             .requestMatchers(

--- a/src/test/java/com/devee/devhive/domain/project/review/evaluation/service/EvaluationServiceTest.java
+++ b/src/test/java/com/devee/devhive/domain/project/review/evaluation/service/EvaluationServiceTest.java
@@ -1,14 +1,19 @@
 package com.devee.devhive.domain.project.review.evaluation.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import com.devee.devhive.domain.badge.entity.dto.BadgeDto;
+import com.devee.devhive.domain.project.entity.Project;
 import com.devee.devhive.domain.project.review.dto.EvaluationForm;
 import com.devee.devhive.domain.project.review.entity.ProjectReview;
-import com.devee.devhive.domain.project.review.evaluation.entity.Evaluation;
 import com.devee.devhive.domain.project.review.evaluation.repository.EvaluationRepository;
+import com.devee.devhive.domain.project.type.DevelopmentType;
+import com.devee.devhive.domain.project.type.ProjectStatus;
+import com.devee.devhive.domain.project.type.RecruitmentType;
 import com.devee.devhive.domain.user.entity.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,31 +41,42 @@ class EvaluationServiceTest {
     User user = User.builder().id(1L).build();
     User targetUser = User.builder().id(2L).build();
 
-    EvaluationForm form = EvaluationForm.builder()
-        .manner(5)
-        .contribution(5)
-        .communication(5)
-        .schedule(5)
-        .professionalism(5)
-        .build();
+    List<EvaluationForm> forms = List.of(
+        EvaluationForm.builder()
+            .badgeDto(BadgeDto.builder().id(1L).name("매너").image("매너 url").build())
+            .point(3)
+            .build(),
+        EvaluationForm.builder()
+            .badgeDto(BadgeDto.builder().id(2L).name("척척박사").image("척척박사 url").build())
+            .point(4)
+            .build());
 
     ProjectReview projectReview = ProjectReview.builder()
         .id(1L)
         .reviewerUser(user)
         .targetUser(targetUser)
-        .totalScore(form.getTotalScore())
+        .project(Project.builder()
+            .id(1L)
+            .user(user)
+            .name("project")
+            .content("모집원 구함")
+            .title("구함")
+            .recruitmentType(RecruitmentType.ONLINE)
+            .developmentType(DevelopmentType.BACKEND)
+            .deadline(LocalDateTime.now().plusMonths(1))
+            .startDate(LocalDateTime.now().minusWeeks(1))
+            .endDate(LocalDateTime.now())
+            .viewCount(3)
+            .teamSize(3)
+            .modifiedDate(LocalDateTime.now().minusDays(1))
+            .status(ProjectStatus.RECRUITMENT_COMPLETE).build())
+        .totalScore(7)
         .build();
 
-    List<Evaluation> evaluationList = evaluationService.getEvaluationList(projectReview, form);
-
-    when(evaluationRepository.saveAll(any()))
-        .thenReturn(evaluationList);
-
     // when
-    List<Evaluation> savedEvaluationList = evaluationService.saveAllEvaluations(projectReview,form);
+    evaluationService.saveAllEvaluations(projectReview, forms);
 
     // then
-    assertThat(savedEvaluationList).isNotNull();
-    assertThat(savedEvaluationList.size()).isEqualTo(5);
+    verify(evaluationRepository, times(1)).saveAll(anyList());
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 리뷰 평가항목 엔티티와 뱃지 엔티티 일대다 매핑관계로 설정
- 유저 뱃지 점수 업데이트 기능
  - 타겟유저에게 리뷰 시 타겟유저의 유저뱃지를 업데이트 합니다. 
  - 타겟유저의 유저뱃지가 없다면(리뷰 받은 적이 없는 유저) -> 서버에 등록된 모든 뱃지를 가지고 유저뱃지를 생성해줍니다.
  -  요청된 평가항목들로 유저뱃지 점수 업데이트 합니다.
- 서버에 등록된 모든 기술스택, 뱃지 목록(이름순으로 정렬) 조회 - 권한 필요없음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 